### PR TITLE
Fix layout stats and whitelisting folders fixes #33339 fixes #33382

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ script_verbose: build
 		--rm mediasite \
 		python3 mediasite_script.py --verbose
 
-script_investigate:
+script_doctor:
 	docker run -it \
 			-v ${CURDIR}:/src \
 			-w /src \
 			--rm mediasite \
-			python3 mediasite_script.py --investigate
+			python3 mediasite_script.py --doctor
 
 stats: build
 	docker run -it \

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ script: build
 		python3 mediasite_script.py
 
 script_dev: build
-ifeq ($(is_build),)
-	make build
-endif
 	docker run -it \
 		-v ${CURDIR}:/src \
 		-w /src \
@@ -22,6 +19,13 @@ script_verbose: build
 		-v ${CURDIR}:/src \
 		--rm mediasite \
 		python3 mediasite_script.py --verbose
+
+script_investigate:
+	docker run -it \
+			-v ${CURDIR}:/src \
+			-w /src \
+			--rm mediasite \
+			python3 mediasite_script.py --investigate
 
 stats: build
 	docker run -it \

--- a/mediasite_script.py
+++ b/mediasite_script.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
-import copy
 import logging
 import json
 from datetime import datetime

--- a/mediasite_script.py
+++ b/mediasite_script.py
@@ -23,6 +23,9 @@ if __name__ == "__main__":
         parser.add_argument('-i', '--info', action='store_true',
                             dest='info', default=False,
                             help='print more status messages to stdout.')
+        parser.add_argument('-inv', '--investigate', action='store_true',
+                            dest='investigate', default=False,
+                            help='check what presentations have not been acounted')
         parser.add_argument('-v', '--verbose', action='store_true',
                             dest='verbose', default=False,
                             help='print all status messages to stdout.')
@@ -102,14 +105,17 @@ if __name__ == "__main__":
         presentations_folders = []
         for folder in folders:
             print('Requesting: ', round(i / len(folders) * 100, 1), '%', end='\r', flush=True)
-            presentations = mediasite.folder.get_folder_presentations(folder['id'])
 
-            for presentation in presentations:
-                presentation['videos'] = get_videos_infos(presentation)
-                presentation['slides'] = get_slides_infos(presentation)
-            presentations_folders.append({**folder,
-                                          'path': find_folder_path(folder['id'], folders),
-                                          'presentations': presentations})
+            path = find_folder_path(folder['id'], folders)
+            if path.startswith('/Presentations II') or path.startswith('/Mediasite Users'):
+                logging.debug('Found folder : ' + path)
+                presentations = mediasite.folder.get_folder_presentations(folder['id'])
+                for presentation in presentations:
+                    presentation['videos'] = get_videos_infos(presentation)
+                    presentation['slides'] = get_slides_infos(presentation)
+                presentations_folders.append({**folder,
+                                              'path': path,
+                                              'presentations': presentations})
             i += 1
         return presentations_folders
 
@@ -281,21 +287,18 @@ if __name__ == "__main__":
                 folder_tree.append(child_folders)
         return folder_tree
 
+    def check_whitelisting(folders):
+        for folder in folders:
+            if not (folder['path'].startswith('/Presentations II') or folder['path'].startswith('/Mediasite Users')):
+                print(folder['path'])
+                return False
+        return True
+
     # ------------------------------- Script
 
     test_dir = 'tests/data'
 
-    # Listing all presentations
-    try:
-        with open('presentations.json') as f:
-            presentations = json.load(f)
-    except Exception as e:
-        logging.debug(e)
-        with open('presentations.json', 'w') as f:
-            presentations = mediasite.presentation.get_all_presentations()
-            json.dump(presentations, f)
-
-    # Listing folders with their presentations
+       # Listing folders with their presentations
     try:
         with open('data.json') as f:
             data = json.load(f)
@@ -307,21 +310,34 @@ if __name__ == "__main__":
             data = order_presentations_by_folder(folders)
             json.dump(data, f)
 
-    # Listing presentations that are not referenced in folders
-    presentations_not_in_folders = list()
-    try:
-        with open('presentations_not_in_folders.json') as f:
-            presentations_not_in_folders = json.load(f)
-    except Exception as e:
-        logging.debug(e)
-        with open('presentations_not_in_folders.json', 'w') as f:
-            presentations_in_folders = []
-            for folder in data:
-                for prez in folder['presentations']:
-                    presentations_in_folders.append(prez)
+    if options.investigate:
+        # Listing all presentations
+        try:
+            with open('presentations.json') as f:
+                presentations = json.load(f)
+        except Exception as e:
+            logging.debug(e)
+            with open('presentations.json', 'w') as f:
+                presentations = mediasite.presentation.get_all_presentations()
+                json.dump(presentations, f)
 
-            presentations_not_in_folders = find_presentations_not_in_folder(presentations, presentations_in_folders)
-            json.dump(presentations_not_in_folders, f)
+        # Listing presentations that are not referenced in folders
+        presentations_not_in_folders = list()
+        try:
+            with open('presentations_not_in_folders.json') as f:
+                presentations_not_in_folders = json.load(f)
+        except Exception as e:
+            logging.debug(e)
+            with open('presentations_not_in_folders.json', 'w') as f:
+                presentations_in_folders = []
+                for folder in data:
+                    for prez in folder['presentations']:
+                        presentations_in_folders.append(prez)
+
+                presentations_not_in_folders = find_presentations_not_in_folder(presentations, presentations_in_folders)
+                json.dump(presentations_not_in_folders, f)
+
+        print(f'Presentations not acounted : {len(presentations_not_in_folders)}. Check on presentations_not_in_folder.json for more infos.')
 
     # Stats
     if options.stats:


### PR DESCRIPTION
Fix layout stats by handling paging results on request with get_folder_presentations() refs #33382. Add whitelisting for folders "Presentations II" and "Mediasite Users" on order_presentations_by_folder() refs #33339