### PR TITLE
Replace slashs in folder name fixes #34085

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ tests_e2e: build
 		--rm mediasite \
 		python3 -m unittest tests/e2e/*.py $(ARGS)
 
+tests_e2e_ext:
+	docker run -it \
+		-v ${CURDIR}:/src \
+		--rm mediasite \
+		python3 -m unittest tests/e2e/e2e_data_extractor.py $(ARGS)
+
 tests_e2e_mdtr: build
 	docker run -it \
 		-v ${CURDIR}:/src \

--- a/mediasite_migration_scripts/data_extractor.py
+++ b/mediasite_migration_scripts/data_extractor.py
@@ -223,7 +223,7 @@ class DataExtractor():
             folder_info = {
                 'id': folder.get('Id', ''),
                 'parent_id': folder.get('ParentFolderId', ''),
-                'name': folder.get('Name', ''),
+                'name': folder.get('Name', '').replace('/', '-'),
                 'owner_username': folder.get('Owner', ''),
                 'description': folder.get('Description', '')
             }

--- a/tests/e2e/e2e_data_extractor.py
+++ b/tests/e2e/e2e_data_extractor.py
@@ -58,6 +58,10 @@ class TestDataExtractorE2E(TestCase):
         for key in folder_keys:
             self.assertIn(key, folder_example.keys())
 
+        for folder in self.extractor.folders:
+            self.assertNotIn('/', folder['name'])
+
+
         catalogs_keys = [
             'id',
             'name',


### PR DESCRIPTION
Replacing '/' by '-', so as to avoid wrong parsing for channel path.